### PR TITLE
fix: Specify main branch for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v2
         with:
+          ref: main
           fetch-depth: 0 # Fetch all tags
       
       # Fetch merged pull request and determine release labels


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?

## Why are we doing this?

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done
