### PR TITLE
fix: replace isPacs002Transaction gate with isStructuredTransaction

### DIFF
--- a/__tests__/unit/logic.service.test.ts
+++ b/__tests__/unit/logic.service.test.ts
@@ -811,6 +811,34 @@ describe('Logic Service', () => {
       expect(getTypologyConfigSpy).toHaveBeenCalledTimes(0);
       expect(responseSpy).toHaveBeenCalledTimes(0);
     });
+
+    it('should return early for unsupported structured transaction type', async () => {
+      const pacs008Transaction = {
+        TxTp: 'pacs.008.001.10',
+        TenantId: 'DEFAULT',
+        FIToFICstmrCdtTrf: {
+          GrpHdr: { MsgId: 'test-msg-id' },
+          CdtTrfTxInf: {},
+        },
+      };
+
+      const networkMap: NetworkMap = getMockNetworkMapPacs002();
+      const ruleResult: RuleResult = {
+        prcgTm: 0,
+        id: '003@1.0.0',
+        tenantId: 'DEFAULT',
+        cfg: '1.0.0',
+        reason: 'reason',
+        subRuleRef: '.01',
+        indpdntVarbl: 0,
+      };
+
+      await handleTransaction({ transaction: pacs008Transaction, networkMap, ruleResult });
+
+      expect(addOneGetAllSpy).toHaveBeenCalledTimes(0);
+      expect(getTypologyConfigSpy).toHaveBeenCalledTimes(0);
+      expect(responseSpy).toHaveBeenCalledTimes(0);
+    });
   });
 
   describe('Review flag, alerts, and interdiction', () => {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -33,6 +33,7 @@ export default defineConfig([
       '@eslint-community/eslint-comments/require-description': ['error', { ignore: ['eslint-enable'] }],
       '@eslint-community/eslint-comments/disable-enable-pair': 'error',
       '@typescript-eslint/class-methods-use-this': 'off',
+      '@typescript-eslint/unified-signatures': 'off', // crashes on SupportedTransactionMessage union param (eslint-plugin bug in <=8.46.2)
       '@typescript-eslint/init-declarations': 'off',
       '@typescript-eslint/max-params': ['warn', { max: 5 }],
       '@typescript-eslint/no-non-null-assertion': 'off',

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@cortex-js/compute-engine": "0.20.2",
-        "@tazama-lf/frms-coe-lib": "8.0.0-rc.2",
-        "@tazama-lf/frms-coe-startup-lib": "3.0.2-rc.4",
+        "@tazama-lf/frms-coe-lib": "^8.0.0-rc.3",
+        "@tazama-lf/frms-coe-startup-lib": "^3.0.2-rc.5",
         "dotenv": "^17.2.1",
         "ioredis": "^5.7.0",
         "node-cache": "^5.1.2",
@@ -1873,9 +1873,9 @@
       }
     },
     "node_modules/@tazama-lf/frms-coe-lib": {
-      "version": "8.0.0-rc.2",
-      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-lib/8.0.0-rc.2/58142df110e5a090fed6f52d3267dc0226859946",
-      "integrity": "sha512-ETed8CuWZHgaYo6Dnr1enaIxJn9pi3ovHGUy3DZo3Q09gX3qifcgYR9icsugJ22NcdGtwD7i4pFhBVfkgYkwWw==",
+      "version": "8.0.0-rc.3",
+      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-lib/8.0.0-rc.3/875069520a1710fff8de65d3788957c4302da9c0",
+      "integrity": "sha512-EATYohwL80vlTrtwGcY/JKIhSqeeu3iZYa6zDjMt4mjCNkvlF/t3NXCz+FCKhLdfkJIJyHrEbLGss0akAPdf/g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",
@@ -1896,12 +1896,12 @@
       }
     },
     "node_modules/@tazama-lf/frms-coe-startup-lib": {
-      "version": "3.0.2-rc.4",
-      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-startup-lib/3.0.2-rc.4/bbfba749d93b1d913d5cd12bfb32b5d6259ee2dd",
-      "integrity": "sha512-PLbAgfQs15v3espsJYbwxFJX/A9OQc2Al94Nu0zXpP5EEBVrXSQQOsNg4oqqh4l3BXX+kdy2VbtsOaq/JFXuIQ==",
+      "version": "3.0.2-rc.5",
+      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-startup-lib/3.0.2-rc.5/dcec3157472b27cd8b274a9dffa6e3f1e7e59124",
+      "integrity": "sha512-Wb179bBsp42PhHJMw1EU2lHXGFITQcGCKozBcV6mi+fIGVxa8iKGGqUbV/ae9g84D45PU0sbRrLGJDqfxsacqw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tazama-lf/frms-coe-lib": "8.0.0-rc.2",
+        "@tazama-lf/frms-coe-lib": "8.0.0-rc.3",
         "amqplib": "0.10.6",
         "axios": "^1.13.5",
         "nats": "^2.29.3"

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@cortex-js/compute-engine": "0.20.2",
-    "@tazama-lf/frms-coe-lib": "^8.0.0-rc.3",
-    "@tazama-lf/frms-coe-startup-lib": "^3.0.2-rc.5",
+    "@tazama-lf/frms-coe-lib": "8.0.0-rc.3",
+    "@tazama-lf/frms-coe-startup-lib": "3.0.2-rc.5",
     "dotenv": "^17.2.1",
     "ioredis": "^5.7.0",
     "node-cache": "^5.1.2",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@cortex-js/compute-engine": "0.20.2",
-    "@tazama-lf/frms-coe-lib": "8.0.0-rc.2",
-    "@tazama-lf/frms-coe-startup-lib": "3.0.2-rc.4",
+    "@tazama-lf/frms-coe-lib": "^8.0.0-rc.3",
+    "@tazama-lf/frms-coe-startup-lib": "^3.0.2-rc.5",
     "dotenv": "^17.2.1",
     "ioredis": "^5.7.0",
     "node-cache": "^5.1.2",

--- a/src/logic.service.ts
+++ b/src/logic.service.ts
@@ -7,7 +7,7 @@ import type { TypologyResult } from '@tazama-lf/frms-coe-lib/lib/interfaces/proc
 import * as util from 'node:util';
 import { configuration, databaseManager, loggerService, server } from '.';
 import { evaluateTypologyExpression } from './utils/evaluateTExpression';
-import { isBaseMessageTransaction, isPacs002Transaction } from '@tazama-lf/frms-coe-lib';
+import { isBaseMessageTransaction, isPacs002Transaction, isStructuredTransaction } from '@tazama-lf/frms-coe-lib';
 
 const saveToRedisGetAll = async (cacheKey: string, ruleResult: RuleResult): Promise<RuleResult[] | undefined> => {
   const currentlyStoredRuleResult = await databaseManager.addOneGetAll(cacheKey, {
@@ -188,8 +188,13 @@ export const handleTransaction = async (req: unknown): Promise<void> => {
   });
 
   let transactionId: string;
-  if (isPacs002Transaction(transaction)) {
-    transactionId = transaction.FIToFIPmtSts.GrpHdr.MsgId;
+  if (isStructuredTransaction(transaction)) {
+    if (isPacs002Transaction(transaction)) {
+      transactionId = transaction.FIToFIPmtSts.GrpHdr.MsgId;
+    } else {
+      loggerService.error('Unsupported structured transaction type', new Error('Unsupported structured transaction type'), context);
+      return;
+    }
   } else if (isBaseMessageTransaction(transaction)) {
     transactionId = transaction.MsgId;
   } else {


### PR DESCRIPTION
## Summary

Replaces the `isPacs002Transaction` outer gate with `isStructuredTransaction` as the umbrella guard for all ISO 20022 structured transaction types, with `isPacs002Transaction` retained as an inner narrowing guard for Pacs002-specific field access.

Also disables the `@typescript-eslint/unified-signatures` lint rule which crashes when it encounters a `SupportedTransactionMessage` union type parameter (bug in `@typescript-eslint/eslint-plugin` <= 8.46.2).

## Changes

- `src/logic.service.ts` - outer gate replaced with `isStructuredTransaction`, inner `isPacs002Transaction` guard retained for field access
- `__tests__/unit/logic.service.test.ts` - new test: unsupported structured type (Pacs008) returns early
- `eslint.config.mjs` - `@typescript-eslint/unified-signatures` disabled to work around linter crash
- `package.json` - lib deps bumped to `frms-coe-lib@8.0.0-rc.3` and `frms-coe-startup-lib@3.0.2-rc.5`

## Related

Closes #404


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved transaction type validation and handling for better robustness.

* **Tests**
  * Added test coverage for unsupported transaction type scenarios.

* **Chores**
  * Updated dependencies to latest compatible versions.
  * Adjusted linting configuration for improved compatibility.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tazama-lf/typology-processor/pull/405)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->