### PR TITLE
ci: use central release workflows (@v1)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,7 @@ on:
 permissions:
   packages: write
   contents: read
+  pull-requests: read
 
 jobs:
   publish:


### PR DESCRIPTION
This PR replaces/updates local release workflows with small caller workflows that use tazama-lf/workflows@v1.